### PR TITLE
add dedupe logic to failing dbt models

### DIFF
--- a/models/staging/stg_nhl__boxscore.sql
+++ b/models/staging/stg_nhl__boxscore.sql
@@ -1,6 +1,10 @@
 with
 live_boxscore as (
     select * from {{ source('meltano', 'live_boxscore') }}
+    qualify row_number() over( -- deduplicate gameids that were ingested more than once
+        partition by
+            gameid
+    ) = 1
 )
 
 , final as (

--- a/models/staging/stg_nhl__boxscore_player.sql
+++ b/models/staging/stg_nhl__boxscore_player.sql
@@ -1,16 +1,14 @@
 with
 -- CTE1
 live_boxscore as (
-    select *
-    from
-        {{ source('meltano', 'live_boxscore') }}
+    select * from {{ source('meltano', 'live_boxscore') }}
 )
 
 -- CTE2
 , home_team_player as (
     select
         /* Identifiers */
-        live_boxscore.gameid as game_id
+        gameid as game_id
         , teams.home.team.id as team_id
         , home_players.person.id as player_id
 
@@ -123,56 +121,57 @@ live_boxscore as (
 -- Final query, return everything
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['boxscore_player.game_id', 'boxscore_player.team_id', 'boxscore_player.player_id']) }} as stg_nhl__boxscore_player_id
+    {{ dbt_utils.surrogate_key(['game_id', 'team_id', 'player_id']) }} as stg_nhl__boxscore_player_id
 
     /* Identifiers */
-    , boxscore_player.game_id
-    , boxscore_player.team_id
-    , boxscore_player.player_id
+    , game_id
+    , team_id
+    , player_id
 
     /* Properties */
-    , boxscore_player.team_name
-    , boxscore_player.team_type
+    , team_name
+    , team_type
 
     /* Player stats */
-    , boxscore_player.player_full_name
-    , boxscore_player.player_roster_status
-    , boxscore_player.player_position_code
-    , boxscore_player.time_on_ice
-    , boxscore_player.assists
-    , boxscore_player.goals
-    , boxscore_player.shots
-    , boxscore_player.hits
-    , boxscore_player.powerplay_goals
-    , boxscore_player.powerplay_assists
-    , boxscore_player.penalty_minutes
-    , boxscore_player.faceoff_wins
-    , boxscore_player.faceoff_taken
-    , boxscore_player.takeaways
-    , boxscore_player.giveaways
-    , boxscore_player.short_handed_goals
-    , boxscore_player.short_handed_assists
-    , boxscore_player.blocked
-    , boxscore_player.plus_minus
-    , boxscore_player.even_time_on_ice
-    , boxscore_player.powerplay_time_on_ice
-    , boxscore_player.short_handed_time_on_ice
-    , boxscore_player.pim
-    , boxscore_player.saves
-    , boxscore_player.powerplay_saves
-    , boxscore_player.short_handed_saves
-    , boxscore_player.even_saves
-    , boxscore_player.short_handed_shots_against
-    , boxscore_player.even_shots_against
-    , boxscore_player.powerplay_shots_against
-    , boxscore_player.decision
-    , boxscore_player.save_percentage
-    , boxscore_player.powerplay_save_percentage
-    , boxscore_player.even_strength_save_percentage
+    , player_full_name
+    , player_roster_status
+    , player_position_code
+    , time_on_ice
+    , assists
+    , goals
+    , shots
+    , hits
+    , powerplay_goals
+    , powerplay_assists
+    , penalty_minutes
+    , faceoff_wins
+    , faceoff_taken
+    , takeaways
+    , giveaways
+    , short_handed_goals
+    , short_handed_assists
+    , blocked
+    , plus_minus
+    , even_time_on_ice
+    , powerplay_time_on_ice
+    , short_handed_time_on_ice
+    , pim
+    , saves
+    , powerplay_saves
+    , short_handed_saves
+    , even_saves
+    , short_handed_shots_against
+    , even_shots_against
+    , powerplay_shots_against
+    , decision
+    , save_percentage
+    , powerplay_save_percentage
+    , even_strength_save_percentage
 
 from boxscore_player
-
-order by
-    boxscore_player.game_id desc
-    , boxscore_player.team_id desc
-    , boxscore_player.player_id desc
+qualify row_number() over(
+    partition by
+        game_id
+        , team_id
+        , player_id
+) = 1

--- a/models/staging/stg_nhl__boxscore_team.sql
+++ b/models/staging/stg_nhl__boxscore_team.sql
@@ -3,6 +3,11 @@ with
 -- CTE1
 live_boxscore as (
     select * from {{ source('meltano', 'live_boxscore') }}
+    qualify row_number() over(
+        partition by
+            gameid
+            , teams.home.team.id
+    ) = 1
 )
 
 -- CTE2

--- a/models/staging/stg_nhl__draft_prospects.sql
+++ b/models/staging/stg_nhl__draft_prospects.sql
@@ -1,35 +1,46 @@
-select distinct
-    /* Primary Key */
-    {{ dbt_utils.surrogate_key(['prospects.id', 'prospects.nhlplayerid']) }} as stg_nhl__draft_prospects_id
+with
 
-    /* Identifiers */
-    , prospects.id as draft_prospect_id
-    , prospects.nhlplayerid as prospect_player_id
-    , prospects.prospectcategory.id as prospect_category_id
+deduped as (
+    select * from {{ source('meltano', 'draft_prospects') }}
+    qualify row_number() over(
+        partition by
+            id
+            , nhlplayerid
+    ) = 1
+)
+
+select
+    /* Primary Key */
+    {{ dbt_utils.surrogate_key(['id', 'nhlplayerid']) }} as stg_nhl__draft_prospects_id
+
+    /* Foreign Keys */
+    , id as draft_prospect_id
+    , nhlplayerid as prospect_player_id
+    , prospectcategory.id as prospect_category_id
 
     /* Properties */
-    , prospects.firstname as prospect_first_name
-    , prospects.lastname as prospect_last_name
-    , prospects.fullname as prospect_full_name
-    , parse_date('%Y-%m-%d', prospects.birthdate) as prospect_birth_date
-    , date_diff(current_date(), parse_date('%Y-%m-%d', prospects.birthdate), year) as prospect_age_years
-    , date_diff(current_date(), parse_date('%Y-%m-%d', prospects.birthdate), day) as prospect_age_days
-    , prospects.birthcity as prospect_birth_city
-    , prospects.birthstateprovince as prospect_birth_state_province
-    , prospects.birthcountry as prospect_birth_country
-    , prospects.height as prospect_height
-    , prospects.weight as prospect_weight
-    , prospects.shootscatches as prospect_shoots_catches
-    , prospects.primaryposition.name as prospect_position_name
-    , prospects.primaryposition.abbreviation as prospect_position_abbreviation
-    , prospects.draftstatus as prospect_draft_status -- wtf is this?
-    , prospects.prospectcategory.name as prospect_category_name
-    , prospects.prospectcategory.shortname as prospect_category_short_name
-    , prospects.amateurteam.name as prospect_amateur_team_name
-    , prospects.amateurteam.link as prospect_amateur_team_url
-    , prospects.amateurleague.name as prospect_amateur_league_name
-    , prospects.amateurleague.link as prospect_amateur_league_url
-    , prospects.ranks.midterm as prospect_rank_midterm
-    , prospects.ranks.draftyear as prospect_rank_draft_year
-    , prospects.link as prospect_url
-from {{ source('meltano', 'draft_prospects') }} as prospects
+    , firstname as prospect_first_name
+    , lastname as prospect_last_name
+    , fullname as prospect_full_name
+    , parse_date('%Y-%m-%d', birthdate) as prospect_birth_date
+    , date_diff(current_date(), parse_date('%Y-%m-%d', birthdate), year) as prospect_age_years
+    , date_diff(current_date(), parse_date('%Y-%m-%d', birthdate), day) as prospect_age_days
+    , birthcity as prospect_birth_city
+    , birthstateprovince as prospect_birth_state_province
+    , birthcountry as prospect_birth_country
+    , height as prospect_height
+    , weight as prospect_weight
+    , shootscatches as prospect_shoots_catches
+    , primaryposition.name as prospect_position_name
+    , primaryposition.abbreviation as prospect_position_abbreviation
+    , draftstatus as prospect_draft_status -- wtf is this?
+    , prospectcategory.name as prospect_category_name
+    , prospectcategory.shortname as prospect_category_short_name
+    , amateurteam.name as prospect_amateur_team_name
+    , amateurteam.link as prospect_amateur_team_url
+    , amateurleague.name as prospect_amateur_league_name
+    , amateurleague.link as prospect_amateur_league_url
+    , ranks.midterm as prospect_rank_midterm
+    , ranks.draftyear as prospect_rank_draft_year
+    , link as prospect_url
+from deduped

--- a/models/staging/stg_nhl__linescore.sql
+++ b/models/staging/stg_nhl__linescore.sql
@@ -1,6 +1,10 @@
 with
 live_linescore as (
     select * from {{ source('meltano', 'live_linescore') }}
+    qualify row_number() over(
+        partition by
+            gameid
+    ) = 1
 )
 
 , final as (

--- a/models/staging/stg_nhl__linescore.yml
+++ b/models/staging/stg_nhl__linescore.yml
@@ -42,7 +42,7 @@ models:
         description: Winning team type (home or away)
         tests:
           - accepted_values:
-              values: [Home, Away]
+              values: [Home, Away, Undetermined]
               quote: true
 
       - name: game_absolute_goal_differential

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -175,6 +175,13 @@ live_plays as (
     , unnest(live_plays.players) as players with offset
     left join {{ ref('stg_nhl__schedule') }} as schedule on schedule.game_id = live_plays.gameid
     left join {{ ref('stg_nhl__boxscore_player') }} as boxscore_player on boxscore_player.game_id = live_plays.gameid and players.player.id = boxscore_player.player_id
+    qualify row_number() over(
+        partition by
+            live_plays.gameid
+            , live_plays.about.eventidx
+            , players.player.id
+            , players.playertype
+    ) = 1
 )
 
 -- #cte3: Add in cumulative metrics

--- a/models/staging/stg_nhl__schedule.sql
+++ b/models/staging/stg_nhl__schedule.sql
@@ -1,16 +1,27 @@
+with
+
+deduped as (
+    select * from {{ source('meltano', 'schedule') }}
+    qualify row_number() over(
+        partition by
+            gamepk
+            , season
+    ) = 1
+)
+
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['schedule.gamepk', 'schedule.season']) }} as stg_nhl__schedule_id
+    {{ dbt_utils.surrogate_key(['gamepk', 'season']) }} as stg_nhl__schedule_id
 
     /* Identifiers */
-    , schedule.gamepk as game_id
-    , schedule.season as season_id
-    , schedule.teams.away.team.id as away_team_id
-    , schedule.teams.home.team.id as home_team_id
-    , schedule.venue.id as venue_id
+    , gamepk as game_id
+    , season as season_id
+    , teams.away.team.id as away_team_id
+    , teams.home.team.id as home_team_id
+    , venue.id as venue_id
 
     /* Properties */
-    , substr(cast(schedule.gamepk as string), 7, 4) as game_number
+    , substr(cast(gamepk as string), 7, 4) as game_number
     , substr(cast(gamepk as string), 5, 2) as game_type
     , case
         when substr(cast(gamepk as string), 5, 2) = '01' then 'Preseason'
@@ -19,30 +30,30 @@ select
         when substr(cast(gamepk as string), 5, 2) = '04' then 'All-star'
         else 'Unknown'
     end as game_type_description
-    , date(schedule.gamedate) as game_date
-    , schedule.status.abstractgamestate as abstract_game_state
-    , schedule.status.codedgamestate as coded_game_state
-    , schedule.status.detailedstate as detailed_state
-    , schedule.status.statuscode as status_code
-    , schedule.status.starttimetbd as is_start_time_tbd
-    , schedule.teams.away.leaguerecord.wins as away_team_wins
-    , schedule.teams.away.leaguerecord.losses as away_team_losses
-    , schedule.teams.away.leaguerecord.ot as away_team_ot
-    , schedule.teams.away.leaguerecord.type as away_team_type
-    , schedule.teams.away.score as away_team_score
-    , schedule.teams.away.team.name as away_team_name
-    , schedule.teams.away.team.link as away_team_url
-    , schedule.teams.home.leaguerecord.wins as home_team_wins
-    , schedule.teams.home.leaguerecord.losses as home_team_losses
-    , schedule.teams.home.leaguerecord.ot as home_team_ot
-    , schedule.teams.home.leaguerecord.type as home_team_type
-    , schedule.teams.home.score as home_team_score
-    , schedule.teams.home.team.name as home_team_name
-    , schedule.teams.home.team.link as home_team_url
-    , schedule.venue.name as venue_name
-    , schedule.venue.link as venue_url
-    , schedule.content.link as content_url
-    , schedule.link as url
-    , schedule._time_extracted as extracted_at
-    , schedule._time_loaded as loaded_at
-from {{ source('meltano', 'schedule') }} as schedule
+    , date(gamedate) as game_date
+    , status.abstractgamestate as abstract_game_state
+    , status.codedgamestate as coded_game_state
+    , status.detailedstate as detailed_state
+    , status.statuscode as status_code
+    , status.starttimetbd as is_start_time_tbd
+    , teams.away.leaguerecord.wins as away_team_wins
+    , teams.away.leaguerecord.losses as away_team_losses
+    , teams.away.leaguerecord.ot as away_team_ot
+    , teams.away.leaguerecord.type as away_team_type
+    , teams.away.score as away_team_score
+    , teams.away.team.name as away_team_name
+    , teams.away.team.link as away_team_url
+    , teams.home.leaguerecord.wins as home_team_wins
+    , teams.home.leaguerecord.losses as home_team_losses
+    , teams.home.leaguerecord.ot as home_team_ot
+    , teams.home.leaguerecord.type as home_team_type
+    , teams.home.score as home_team_score
+    , teams.home.team.name as home_team_name
+    , teams.home.team.link as home_team_url
+    , venue.name as venue_name
+    , venue.link as venue_url
+    , content.link as content_url
+    , link as url
+    , _time_extracted as extracted_at
+    , _time_loaded as loaded_at
+from deduped

--- a/models/staging/stg_nhl__shifts.sql
+++ b/models/staging/stg_nhl__shifts.sql
@@ -19,19 +19,19 @@ shifts_raw as (
         , s.duration
         , case
             when s.starttime is not null
-                 then cast( split(s.starttime, ':')[offset(0)] as int64)
+                 then cast(split(s.starttime, ':')[offset(0)] as int64)
         end as start_time_mins
         , case
             when s.starttime is not null
-                 then cast( split(s.starttime, ':')[offset(1)] as int64)
+                 then cast(split(s.starttime, ':')[offset(1)] as int64)
         end as start_time_seconds
         , case
             when s.duration is not null
-                 then cast( split(s.duration, ':')[offset(0)] as int64)
+                 then cast(split(s.duration, ':')[offset(0)] as int64)
         end as duration_mins
         , case
             when s.duration is not null
-                 then cast( split(s.duration, ':')[offset(1)] as int64)
+                 then cast(split(s.duration, ':')[offset(1)] as int64)
         end as duration_seconds
         , concat(s.firstname, " ", s.lastname) as player_full_name
         , case

--- a/models/staging/stg_nhl__shifts.sql
+++ b/models/staging/stg_nhl__shifts.sql
@@ -1,4 +1,6 @@
-with shifts_raw as (
+with
+
+shifts_raw as (
     select
         s.id as shift_id
         , s.shiftnumber as shift_number
@@ -210,7 +212,7 @@ with shifts_raw as (
 
 )
 
-select distinct
+select
     concat('newshiftid_', revised_new_shift_number, new_shift_id) as shift_id
     , game_id
     , player_id
@@ -240,3 +242,8 @@ select distinct
     , goal_primary_assister_full_name
     , goal_secondary_assister_full_name
 from new_shifts_time
+qualify row_number() over(
+    partition by
+        revised_new_shift_number
+        , new_shift_id
+) = 1


### PR DESCRIPTION
# Overview
some duplicate data was loaded into the raw tables, causing dbt test failures. This PR adds deduplication logic to ensure that our tests pass and then duplicated rows aren't propagated to downstream models.

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
