### PR TITLE
Feature/use full dataset macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ dbt_nhl_breakouts:
 
 Install the SQLFluff templater for dbt:
 ```bash
-pip install sqlfluff-templater-dbt
+pip install sqlfluff
 ```
 
 Run the linter:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,6 +25,9 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+vars:
+  full_dataset_target_names: ['prod', 'production']
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 

--- a/macros/use_full_dataset.sql
+++ b/macros/use_full_dataset.sql
@@ -1,0 +1,9 @@
+{#
+-- Returns true if the target is in the targets defined by the variable `full_dataset_target_names` in `dbt_project.yml`
+-- This value can be overridden by passing --vars "{use_full_dataset: true}" to dbt.
+-- e.g. `dbt run --vars "{use_full_dataset: true}"`
+#}
+
+{% macro use_full_dataset() %}
+    {{ return(var('use_full_dataset', target.name in var('full_dataset_target_names'))) }}
+{% endmacro %}

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -402,7 +402,7 @@ select
     , oss.shots_pp_iscored
     , oss.shots_pp_ixg
     ----- power-play (pp)
-    , oss.oss.shots_sh_isog
+    , oss.shots_sh_isog
     , oss.shots_sh_iff
     , oss.shots_sh_imissed
     , oss.shots_sh_isaved

--- a/models/staging/stg_nhl__boxscore.sql
+++ b/models/staging/stg_nhl__boxscore.sql
@@ -143,3 +143,7 @@ deduped as (
 )
 
 select * from unioned
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__conferences.sql
+++ b/models/staging/stg_nhl__conferences.sql
@@ -12,3 +12,7 @@ select
     , conferences.active as is_active
     , conferences.link as conference_url
 from {{ source('meltano', 'conferences') }} as conferences
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__divisions.sql
+++ b/models/staging/stg_nhl__divisions.sql
@@ -14,3 +14,7 @@ select
     , divisions.active as is_active
 
 from {{ source('meltano', 'divisions') }} as divisions
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__draft.sql
+++ b/models/staging/stg_nhl__draft.sql
@@ -18,3 +18,7 @@ select
 
 from {{ source('meltano', 'draft') }} as draft
 where draft.prospect.fullname != 'Void' -- remove records that contain draft prospect named 'Void' as this appears to be bad data from the API
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__draft_prospects.sql
+++ b/models/staging/stg_nhl__draft_prospects.sql
@@ -44,3 +44,7 @@ select
     , ranks.draftyear as prospect_rank_draft_year
     , link as prospect_url
 from deduped
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__linescore.sql
+++ b/models/staging/stg_nhl__linescore.sql
@@ -45,3 +45,7 @@ live_linescore as (
 )
 
 select * from final
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -566,3 +566,7 @@ select
 
 from game_state as gs
 left join last_shot as ls on ls.stg_nhl__live_plays_id = gs.stg_nhl__live_plays_id
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__live_plays_location.sql
+++ b/models/staging/stg_nhl__live_plays_location.sql
@@ -98,3 +98,7 @@ select
     end as zone
 
 from adj_coordinates
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__players.sql
+++ b/models/staging/stg_nhl__players.sql
@@ -33,3 +33,7 @@ select
     , players._time_extracted as extracted_at
     , players._time_loaded as loaded_at
 from {{ source('meltano', 'people') }} as players
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__rink_shooting.sql
+++ b/models/staging/stg_nhl__rink_shooting.sql
@@ -95,3 +95,7 @@ from
     p1_team_game_shots_home as p1
 left join p3_team_game_shots_home as p3 on p3.game_id = p1.game_id and p3.team_id = p1.team_id
 order by p1.game_id
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__schedule.sql
+++ b/models/staging/stg_nhl__schedule.sql
@@ -57,3 +57,7 @@ select distinct
     , _time_extracted as extracted_at
     , _time_loaded as loaded_at
 from deduped
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__seasons.sql
+++ b/models/staging/stg_nhl__seasons.sql
@@ -18,3 +18,7 @@ select
     , seasons._time_extracted as extracted_at
     , seasons._time_loaded as loaded_at
 from {{ source('meltano', 'seasons') }} as seasons
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__shifts.sql
+++ b/models/staging/stg_nhl__shifts.sql
@@ -56,3 +56,7 @@ where
     and not (gameid = 2020030412 and eventnumber = 614 and id = 11050284) -- time of goal was off
     and not (gameid = 2020020745 and eventnumber = 485 and id = 10875539) -- time of goal was off
     and not (gameid = 2020020767 and eventnumber = 209 and id = 10639438) -- time of goal was off
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__teams.sql
+++ b/models/staging/stg_nhl__teams.sql
@@ -36,3 +36,7 @@ select
     , teams._time_extracted as extracted_at
     , teams._time_loaded as loaded_at
 from {{ source('meltano', 'teams') }} as teams
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}

--- a/models/staging/stg_nhl__xg.sql
+++ b/models/staging/stg_nhl__xg.sql
@@ -67,3 +67,7 @@ select
     , id_model_insert_model_ts as _model_time_loaded
 
 from deduped
+
+{% if not use_full_dataset() %}
+limit 1000
+{% endif %}


### PR DESCRIPTION
# Overview
`use_full_dataset` is a macro (function) that returns `true` or `false` depending on the environment on which dbt is running. For instance during development, this will return `false`. Any models that have a clause that is conditional on `use_full_dataset` will limit the amount of data that is being processed when dbt is run.

# Example usage
Given the following `my_model.sql`
```sql
select * from {{ source('db', 'source') }}
{% if not use_full_dataset() %}
limit 1000
{% endif %}
```

When running `dbt build --select my_model`, the model will compile to
```sql
select * from db.source
limit 1000
```

When running `dbt build --select my_model --vars "{use_full_dataset: true}"` or if running in `production`:
```sql
select * from db.source
```

# Checks
- [x] All models ran successfully
- [x] All tests passed
- [x] Changes to models are reflected in the schema.yml
