### PR TITLE
Added d_player_team_season to analytics_core

### DIFF
--- a/models/analytics/core/d_player_team_season.sql
+++ b/models/analytics/core/d_player_team_season.sql
@@ -1,0 +1,45 @@
+with
+player_team_season as (
+    select
+        box.player_id
+        , team.team_id
+        , season.season_id
+        , count(1) over (partition by box.player_id, season.season_id) as player_season_teams
+        , count(distinct box.game_id) as games_played
+        , sum(cast(split(box.time_on_ice, ':')[offset(0)] as int)) + (sum(cast(split(box.time_on_ice, ':')[offset(1)] as int)) / 60) as time_on_ice_minutes
+        , min(schedule.game_date) as season_start_dt
+        , max(schedule.game_date) as season_end_dt
+        , max(season.season_id) over () as current_season_id
+    from {{ ref('f_boxscore_player') }} as box
+    left join {{ ref('d_schedule') }} as schedule on box.game_id = schedule.game_id
+    left join{{ ref('d_seasons') }} as season on season.season_id = schedule.season_id
+    left join {{ ref('d_teams') }} as team on box.team_id = team.team_id
+    left join {{ ref('f_games_scratches') }} as scratches on box.player_id = scratches.player_id and box.game_id = scratches.game_id
+    where schedule.game_type in ('02', '03') and scratches.player_id is null
+    group by
+        box.player_id
+        , team.team_id
+        , season.season_id
+)
+
+select
+    /* primary key */
+    {{ dbt_utils.surrogate_key(['pts.player_id', 'pts.team_id', 'pts.season_id']) }} as player_team_season_id
+    /* foreign keys */
+    , pts.player_id
+    , pts.team_id
+    , pts.season_id
+    /* properties */
+    , pts.player_season_teams
+    , case when min(pts.season_start_dt) over (partition by pts.player_id, pts.season_id) = pts.season_start_dt then 1 else 0 end as is_player_team_start_season
+    , case when max(pts.season_end_dt) over (partition by pts.player_id, pts.season_id) = pts.season_end_dt then 1 else 0 end as is_player_team_end_season
+    , case when max(pts.season_end_dt) over (partition by pts.player_id, pts.season_id) = pts.season_end_dt and pts.season_id = pts.current_season_id and player.is_active is true then 1 else 0 end as is_player_current_team
+    , coalesce(not player.is_active, true) as is_player_retired
+    , pts.games_played
+    , pts.time_on_ice_minutes
+    , pts.season_start_dt as player_season_team_first_dt
+    , pts.season_end_dt as player_season_team_last_dt
+    , min(pts.season_start_dt) over (partition by pts.player_id) as career_first_dt
+    , max(pts.season_end_dt) over (partition by pts.player_id) as career_last_dt
+from player_team_season as pts
+left join {{ ref('d_players') }} as player on pts.player_id = player.player_id

--- a/models/analytics/core/d_player_team_season.sql.yml
+++ b/models/analytics/core/d_player_team_season.sql.yml
@@ -1,0 +1,56 @@
+version: 2
+
+models:
+  - name: d_player_team_season
+    description: Model-ready, dimensions dataset at the player-team-season level
+    columns:
+      # Primary Key
+      - name: player_team_season_id
+        description: Unique identifier at the player-team-season level (player_id + team_id + season_id)
+        tests:
+          - unique
+          - not_null
+
+      # Foreign Keys
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+
+      - name: season_id
+        description: Foreign key that maps to an NHL season ID (e.g. "20172018")
+
+      # Properties
+      - name: player_season_teams
+        description: The number of teams that a player played for in the season (e.g. If "3", the player played for 3 different teams in that season)
+
+      - name: is_player_team_start_season
+        description: Whether or not the NHL player started the season on the team
+
+      - name: is_player_team_end_season
+        description: Whether or not the NHL player ended the season on the team
+
+      - name: is_player_current_team
+        description: Whether or not the NHL player is currently on that team (True / False). Note that "current" is defined as an NHL player being active, had to have played in the most recent season, and their latest game being played for the team.
+
+      - name: is_player_retired
+        description: Whether or not the NHL player is currently retired (True / False)
+
+      - name: games_played
+        description: The number of games played for the team in the season
+
+      - name: time_on_ice_minutes
+        description: The number of minutes played for the team in the season
+
+      - name: player_season_team_first_dt
+        description: The date that a NHL player made his debut (first game) for the team in the season
+
+      - name: player_season_team_last_dt
+        description: The date that a NHL player made his farewell (last game) for the team in the season
+
+      - name: career_first_dt
+        description: The date of the very first NHL regular season or playoff game played by the NHL player during his career
+
+      - name: career_last_dt
+        description: The date of the most recent NHL regular season or playoff game played by the NHL player during his career

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -328,23 +328,22 @@ boxscore_stats as (
 
 -- cte#7: summarizes penalty mins at the player-season-game_type level
 , penalty_stats as (
-  select
-    plays.player_id
-    ,season.season_id
-    ,schedule.game_type
-    ,sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as minor_pim_taken
-    ,sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as minor_pim_drawn
-    ,sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as major_pim_taken
-    ,sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as major_pim_drawn
-  from {{ ref('f_plays') }} as plays
+    select
+        plays.player_id
+        , season.season_id
+        , schedule.game_type
+        , sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as minor_pim_taken
+        , sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as minor_pim_drawn
+        , sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as major_pim_taken
+        , sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as major_pim_drawn
+    from {{ ref('f_plays') }} as plays
     left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
     left join {{ ref('d_seasons') }} as season on season.season_id = schedule.season_id
-  where 1 = 1
-    and lower(plays.event_type) = 'penalty'
-  group by
-    plays.player_id
-    ,season.season_id
-    ,schedule.game_type
+    where lower(plays.event_type) = 'penalty'
+    group by
+        plays.player_id
+        , season.season_id
+        , schedule.game_type
 )
 
 -- #return: combine boxscore_stats & onice_stats at the player-season-game_type level of granularity

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -324,7 +324,27 @@ boxscore_stats as (
         sga.player_id
         , sga.season_id
         , sga.game_type
---order by sum(case when sga.event_type = 'goal' and sga.player_role = 'scorer' then 1 else 0 end) desc
+)
+
+-- cte#7: summarizes penalty mins at the player-season-game_type level
+, penalty_stats as (
+  select
+    plays.player_id
+    ,season.season_id
+    ,schedule.game_type
+    ,sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as minor_pim_taken
+    ,sum(case when lower(plays.penalty_severity) = 'minor' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as minor_pim_drawn
+    ,sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'penaltyon' then plays.penalty_minutes else 0 end) as major_pim_taken
+    ,sum(case when lower(plays.penalty_severity) = 'major' and lower(plays.player_role) = 'drewby' then plays.penalty_minutes else 0 end) as major_pim_drawn
+  from {{ ref('f_plays') }} as plays
+    left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
+    left join {{ ref('d_seasons') }} as season on season.season_id = schedule.season_id
+  where 1 = 1
+    and lower(plays.event_type) = 'penalty'
+  group by
+    plays.player_id
+    ,season.season_id
+    ,schedule.game_type
 )
 
 -- #return: combine boxscore_stats & onice_stats at the player-season-game_type level of granularity
@@ -351,6 +371,10 @@ select
     , boxscore_stats.time_on_ice_seconds
     , round(boxscore_stats.time_on_ice_minutes, 2) as time_on_ice_minutes
     , round(boxscore_stats.time_on_ice_minutes / boxscore_stats.boxscore_games, 2) as avg_time_on_ice_mins
+    , ps.minor_pim_drawn
+    , ps.minor_pim_taken
+    , ps.major_pim_drawn
+    , ps.major_pim_taken
     -- goal-scoring skater events (goals, assists, points)
     , boxscore_stats.goals
     , ogs.goals_gamewinning
@@ -535,5 +559,10 @@ left join onice_goals_stats as ogs
         boxscore_stats.player_id = ogs.player_id
         and boxscore_stats.season_id = ogs.season_id
         and boxscore_stats.game_type = ogs.game_type
+left join penalty_stats as ps
+    on
+        boxscore_stats.player_id = ps.player_id
+        and boxscore_stats.season_id = ps.season_id
+        and boxscore_stats.game_type = ps.game_type
 order by
     boxscore_stats.goals desc

--- a/models/analytics/core/f_player_season.yml
+++ b/models/analytics/core/f_player_season.yml
@@ -57,6 +57,18 @@ models:
       - name: avg_time_on_ice_mins
         description: The number of minutes played in the regular seasons divided by the number of games played in the regular season (e.g. 20.5 = 20 minutes and 30 seconds)
 
+      - name: minor_pim_drawn
+        description: The number of minor penalty minutes the player drew
+
+      - name: minor_pim_taken
+        description: The number of minor penalty minutes the player took
+
+      - name: major_pim_drawn
+        description: The number of major penalty minutes the player drew
+
+      - name: major_pim_taken
+        description: The number of major penalty minutes the player took
+
       ## Goal-scoring skater events (Goals, Assists, Points)
       - name: goals
         description: The number of goals scored in the regular season


### PR DESCRIPTION
# Overview
- Added a team-player-season level dimensions table to `analytics_core` schema
- Value add - now, can get a player's "current" team
- todo... add player's headshots at the team-season level

# Checks
- [ ] All models ran successfully
- [ ] All tests passed
- [ ] Changes to models are reflected in the schema.yml
