### PR TITLE
Adding Game Winning Goal Indicator

### DIFF
--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -75,6 +75,7 @@ boxscore_stats as (
         , team.team_name
         , schedule.game_type
         , plays.last_goal_game_winning
+        , plays.game_winning_goal
         , plays.player_primary_assist
         , plays.player_secondary_assist
         , lower(schedule.game_type_description) as game_type_description
@@ -285,7 +286,7 @@ boxscore_stats as (
         , sga.game_type
         , max(sga.event_description) as example_eventdescription
         -- goal types
-        , sum(case when sga.last_goal_game_winning = 1 and sga.player_role = 'scorer' then 1 else 0 end) as goals_gamewinning
+        , sum(case when sga.game_winning_goal = 1 and sga.player_role = 'scorer' then 1 else 0 end) as goals_gamewinning
         , sum(case when (sga.home_result_of_play = 'chase goal' or sga.away_result_of_play = 'chase goal') and sga.player_role = 'scorer' then 1 else 0 end) as goals_chasegoal
         , sum(case when (sga.home_result_of_play = 'tying goal scored' or sga.away_result_of_play = 'tying goal scored') and sga.player_role = 'scorer' then 1 else 0 end) as goals_gametying
         , sum(case when (sga.home_result_of_play = 'go-ahead goal scored' or sga.away_result_of_play = 'go-ahead goal scored') and sga.player_role = 'scorer' then 1 else 0 end) as goals_goahead

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -66,6 +66,7 @@ select
     , plays.penalties_home
     , plays.first_goal_scored
     , plays.last_goal_scored
+    , plays.game_winning_goal
     , plays.goals_away
     , plays.goals_home
     , plays.goal_difference_current

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -172,6 +172,9 @@ models:
       - name: last_goal_scored
         description: Whether or not the event in question was the last goal of the game (1 or 0)
 
+      - name: game_winning_goal
+        description: Whether or not the event in question was the game winning goal (1 or 0)
+
       - name: goals_away
         description: Cumulative away team goals scored in the game at the point in time where the event occured
 

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -186,19 +186,23 @@ live_plays as (
         -- GOALS
         , live_plays.about.goals.away as goals_away
         , live_plays.about.goals.home as goals_home
-        , case 
+        , case
             when
-                (upper(live_plays.result.eventtypeid) = 'GOAL'
-                and live_plays.team.id = schedule.home_team_id
-                and upper(players.player_type) = 'SCORER'
-                and upper(live_plays.about.periodtype) != 'SHOOTOUT'
-                and live_plays.about.goals.home - linescore.away_team_goals = 1)
-                or 
-                (upper(live_plays.result.eventtypeid) = 'GOAL'
-                and live_plays.team.id = schedule.away_team_id
-                and upper(players.player_type) = 'SCORER'
-                and upper(live_plays.about.periodtype) != 'SHOOTOUT'
-                and live_plays.about.goals.away - linescore.home_team_goals = 1)
+                (
+                    upper(live_plays.result.eventtypeid) = 'GOAL'
+                    and live_plays.team.id = schedule.home_team_id
+                    and upper(players.playertype) = 'SCORER'
+                    and upper(live_plays.about.periodtype) != 'SHOOTOUT'
+                    and live_plays.about.goals.home - linescore.away_team_goals = 1
+                )
+                or
+                (
+                    upper(live_plays.result.eventtypeid) = 'GOAL'
+                    and live_plays.team.id = schedule.away_team_id
+                    and upper(players.playertype) = 'SCORER'
+                    and upper(live_plays.about.periodtype) != 'SHOOTOUT'
+                    and live_plays.about.goals.away - linescore.home_team_goals = 1
+                )
                 then 1
             else 0
         end as game_winning_goal

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -159,6 +159,9 @@ models:
       - name: last_goal_scored
         description: Whether or not the event in question was the last goal of the game (1 or 0)
 
+      - name: game_winning_goal
+        description: Whether or not the event in question was the game winning goal (1 or 0)
+
       - name: goals_away
         description: Cumulative away team goals scored in the game at the point in time where the event occured
 


### PR DESCRIPTION
# Overview
Added in a Game Winning Goal indicator into `stg_nhl__live_plays.sql`. This will be marked 1 if the goal scored was one more than the opposing team's final goal count, no matter when it was scored. 

# Example
### Team A vs. Team B
- Game Start
- Player A scores (A 1 - B 0) (game_winning_goal = 0)
- Player A scores (A 2 - B 0) (game_winning_goal = 0)
- Player A scores (A 3 - B 0) (game_winning_goal = 1)
- Player B scores (A 3 - B 1) (game_winning_goal = 0)
- Player B scores (A 3 - B 2) (game_winning_goal = 0)
- Game End

# Checks
- [✔️] All models ran successfully
- [✔️] All tests passed
- [✔️] Changes to models are reflected in the schema.yml
